### PR TITLE
refactor(typeahead): move response unwrapping to separate combinator …

### DIFF
--- a/src/components/typeahead/typeahead.ts
+++ b/src/components/typeahead/typeahead.ts
@@ -37,7 +37,10 @@ export class TypeAhead {
       // (cancelling it), and subscribing to the newly returned on here.
       .switchMap(val => {
         return http.request(`http://localhost:3000/stocks?symbol=${val}`)
-      }, (val:string, res:Response) => res.json())
+      })
+      // Serialize the response into a plain ole' JavaScript object
+      // representation of the body.
+      .map((res:Response) => res.json())
       // send an empty array to tickers whenever clear emits by
       // merging in a the stream of clear events mapped to an
       // empty array.


### PR DESCRIPTION
…for readability

In order to reduce the cognitive overhead of understanding the chain of combinators,
I moved the res.json() step to a separate map operation after the fact.

Since this isn't a performance-critical hot path, the cost of separating into
a separate step isn't a big concern.

If @blesh's demo goes deep into the power of switchMap, then we can leave it as is,
but @robwormald and I were hoping to simplify by breaking into two steps.
